### PR TITLE
Bump to v1.9.31: special-dataset op, skip_process_dataset, and shared…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Optional top-level `operation` (default `data_validation`):
 | `open_assignments_sync` | Sync open assignments from Airtable |
 | `weekly_report` | Weekly ops report to Slack |
 | `redivis_individual_release` | Per-site scheduler + Redivis provisioning |
+| `special_dataset_validation` | Build a multi-site raw/processed dataset from Airtable Special Dataset rows |
 
 ### Data validation example
 
@@ -125,6 +126,8 @@ Optional top-level `operation` (default `data_validation`):
 Notes:
 - Required fields: `dataset_id`, `is_save_to_storage`, `orgs` (non-empty list).
 - `send_slack`: if `true`, posts Slack when the job starts, per-site progress (multi-org), and a final summary. Failures always post to Slack.
+- `skip_process_dataset`: if `true`, release raw only and do not run the `process_dataset` notebook. Omit, `false`, or `null` keep the default (run processing after a new raw release). Existing cron jobs need no change.
+- After a new raw release, the job runs the shared Redivis notebook `process_dataset` on workflow `process_dataset:zr0v`. If another site already holds that notebook (`Notebook is already running`), the job waits and retries (re-pointing the datasource each attempt) for up to `REDIVIS_PROCESS_BUSY_RETRY_MAX_SECONDS` (default 1 hour).
 - Task timeout: **24 hours** (`86400s`).
 - If `is_save_to_storage` is `false`, the job validates and returns stats only.
 
@@ -136,6 +139,29 @@ Notes:
 
 ```json
 {"operation": "redivis_individual_release", "dry_run": false, "dataset_name": "optional-single-site"}
+```
+
+```json
+{"operation": "special_dataset_validation", "dataset_name": "levante-data-pilots-raw"}
+```
+
+This operation reads matching rows from Airtable table `tbllc141VVhJfsKNa`,
+builds one validator organization scope per row, forces a new raw Redivis release,
+runs `process_dataset`, verifies that the unmarked processed dataset received a
+new released version, backfills empty `processed_ref_id` cells, and posts one
+Slack summary.
+
+Test mode uses the same live Airtable query scopes but redirects all Redivis/GCS
+output to an explicit test raw dataset. It skips Airtable `processed_ref_id`
+verification/writeback and still sends Slack:
+
+```json
+{
+  "operation": "special_dataset_validation",
+  "dataset_name": "levante-data-pilots-raw",
+  "test_mode": true,
+  "test_dataset_name": "TEST-ethan-special-dataset-raw"
+}
 ```
 
 ```json

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ the first CLI argument, or set ``DATA_VALIDATOR_PAYLOAD_FILE``, or pipe JSON on 
 - ``open_assignments_sync`` — sync open assignments from Airtable
 - ``weekly_report`` — weekly ops report to Slack
 - ``redivis_individual_release`` — Airtable ↔ Redivis individual provisioning
+- ``special_dataset_validation`` — Airtable special rows → raw + processed dataset
 - ``migrate_scheduler_jobs`` — migrate daily cron jobs to the Cloud Run Job API
 
 For ``data_validation``, the payload matches ``DatasetParameters`` (same as before,
@@ -182,6 +183,29 @@ def _run_redivis_individual_release(data: dict) -> int:
     return 0
 
 
+def _run_special_dataset_validation(data: dict) -> int:
+    from sync.special_dataset import run_special_dataset_validation
+
+    dataset_name = str(data.get("dataset_name") or "").strip()
+    test_mode_raw = data.get("test_mode", False)
+    test_mode = (
+        test_mode_raw.strip().lower() in ("1", "true", "yes")
+        if isinstance(test_mode_raw, str)
+        else bool(test_mode_raw)
+    )
+    test_dataset_name = str(data.get("test_dataset_name") or "").strip() or None
+    result = run_special_dataset_validation(
+        dataset_name,
+        test_mode=test_mode,
+        test_dataset_name=test_dataset_name,
+    )
+    logging.info(
+        "special_dataset_validation result: %s",
+        json.dumps(result, cls=utils.CustomJSONEncoder),
+    )
+    return 0 if result.get("success") else 1
+
+
 def main() -> int:
     utils.setup_project_environment()
 
@@ -206,6 +230,8 @@ def main() -> int:
         return _run_weekly_report(payload)
     if operation == "redivis_individual_release":
         return _run_redivis_individual_release(payload)
+    if operation == "special_dataset_validation":
+        return _run_special_dataset_validation(payload)
     if operation == "migrate_scheduler_jobs":
         return _run_migrate_scheduler_jobs(payload)
 

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,6 @@
 
 config = {
-    'VERSION': '1.9.30',
+    'VERSION': '1.9.31',
     'INSTANCE': 'LEVANTE',
     'EXTERNAL_DATA_BUCKET_NAME': 'levante-external-data',
     'ADMIN_SERVICE_ACCOUNT_SECRET_ID': 'adminServiceAccount',
@@ -18,6 +18,19 @@ config = {
     'AIRTABLE_API_TOKEN_SECRET_ID': 'airtableTokenUpdateEntitiesDatasets',
     'AIRTABLE_LEVANTE_ENTITIES_BASE_ID': 'appIDUfcKdekzTiIJ',
     'AIRTABLE_DATASET_TABLE_ID': 'tblu4NwcVZX9MbuWK',
+    # Rows that define multi-site "special" raw datasets and their query scopes.
+    'AIRTABLE_SPECIAL_DATASET_TABLE_ID': 'tbllc141VVhJfsKNa',
+    'AIRTABLE_SPECIAL_FIELD_DATASET_NAME': 'dataset_name',
+    'AIRTABLE_SPECIAL_FIELD_DATASET_REF_ID': 'dataset_ref_id',
+    'AIRTABLE_SPECIAL_FIELD_PROCESSED_NAME': 'processed_name',
+    'AIRTABLE_SPECIAL_FIELD_PROCESSED_REF_ID': 'processed_ref_id',
+    'AIRTABLE_SPECIAL_FIELD_START_DATE': 'start_date',
+    'AIRTABLE_SPECIAL_FIELD_END_DATE': 'end_date',
+    'AIRTABLE_SPECIAL_FIELD_DATASET_LINK': 'dataset_link',
+    'AIRTABLE_SPECIAL_FIELD_ORG_ID': 'org_id',
+    'AIRTABLE_SPECIAL_FIELD_USER_LIMIT': 'user_limit',
+    'AIRTABLE_SPECIAL_FIELD_IS_GUEST': 'is_guest',
+    'AIRTABLE_SPECIAL_FIELD_USER_FILTER': 'user_filter',
     'AIRTABLE_FIELD_FIRESTORE_SITE_ID': 'Firestore siteId',
     'AIRTABLE_FIELD_OPEN_ASSIGNMENTS': 'Open Assignments',
     'AIRTABLE_FIELD_REDIVIS_INDIVIDUAL': 'Redivis individual',
@@ -40,6 +53,12 @@ config = {
     'REDIVIS_PROCESS_WORKFLOW_USER': 'levante',
     'REDIVIS_PROCESS_WORKFLOW_NAME': 'process_dataset:zr0v',
     'REDIVIS_PROCESS_NOTEBOOK_NAME': 'process_dataset',
+    # Shared notebook: per-site jobs may hit "Notebook is already running". Wait/retry
+    # until free (total budget), with exponential backoff between attempts.
+    'REDIVIS_PROCESS_BUSY_RETRY_MAX_SECONDS': 3600,
+    'REDIVIS_PROCESS_BUSY_RETRY_INITIAL_SECONDS': 30,
+    'REDIVIS_PROCESS_BUSY_RETRY_MAX_SLEEP_SECONDS': 120,
+    'REDIVIS_PROCESS_BUSY_POLL_SECONDS': 30,
     # Placeholder written into Firestore siteId when no Firestore district matches.
     'MISSING_SITE_ID_PLACEHOLDER': 'missing_site_id',
     # Cloud Scheduler config used to provision daily data-validator jobs per site.

--- a/shared/airtable_services.py
+++ b/shared/airtable_services.py
@@ -28,6 +28,9 @@ class AirtableServices:
             )
         self._api = Api(token)
         self._table = self._api.table(base_id, table_id)
+        self._special_dataset_table = self._api.table(
+            base_id, settings.config["AIRTABLE_SPECIAL_DATASET_TABLE_ID"]
+        )
 
     def list_dataset_records(self, *, formula: str | None = None) -> list[dict]:
         """
@@ -40,6 +43,34 @@ class AirtableServices:
 
     def update_record_fields(self, record_id: str, fields: dict) -> dict:
         return self._table.update(record_id, fields)
+
+    def get_dataset_record(self, record_id: str) -> dict:
+        """Get one row from the primary Dataset table (used by linked records)."""
+        return self._table.get(record_id)
+
+    def list_special_dataset_records(self, dataset_name: str) -> list[dict]:
+        """List Special Dataset rows matching ``dataset_name``."""
+        dataset_name = (dataset_name or "").strip()
+        if not dataset_name:
+            return []
+        field = settings.config["AIRTABLE_SPECIAL_FIELD_DATASET_NAME"]
+        escaped = dataset_name.replace("\\", "\\\\").replace('"', '\\"')
+        rows = self._special_dataset_table.all(
+            formula=f'{{{field}}}="{escaped}"'
+        )
+        # Also enforce an exact normalized match locally.
+        wanted = dataset_name.casefold()
+        return [
+            row
+            for row in rows
+            if str((row.get("fields") or {}).get(field) or "").strip().casefold()
+            == wanted
+        ]
+
+    def update_special_dataset_record_fields(
+        self, record_id: str, fields: dict
+    ) -> dict:
+        return self._special_dataset_table.update(record_id, fields)
 
     def find_dataset_record_by_name(self, name: str) -> dict | None:
         """Return the Dataset row whose ``Name`` equals ``name``, or None."""

--- a/shared/firestore_services.py
+++ b/shared/firestore_services.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import random
 import warnings
 from collections import defaultdict
@@ -361,21 +362,61 @@ class FirestoreServices:
     def __init__(self):
         self._admin_db = None
         self._admin_credentials = None
+        self._admin_db_project_id = None
+        self._admin_credentials_source = None
 
     @property
     def admin_credentials(self):
         if self._admin_credentials is None:
+            # Local runs: use LOCAL_ADMIN_SERVICE_ACCOUNT (ADC) so admin-dev vs
+            # admin-prod is chosen by the key file, not Secret Manager.
+            if (os.getenv("ENV") or "").strip().lower() == "local":
+                sa_path = (
+                    (os.getenv("LOCAL_ADMIN_SERVICE_ACCOUNT") or "").strip()
+                    or (os.getenv("GOOGLE_APPLICATION_CREDENTIALS") or "").strip()
+                )
+                if sa_path:
+                    self._admin_credentials = (
+                        service_account.Credentials.from_service_account_file(
+                            sa_path
+                        )
+                    )
+                    self._admin_credentials_source = sa_path
+                    return self._admin_credentials
             info = json.loads(
-                secret_service.get_secret_payload(secret_id=settings.config['ADMIN_SERVICE_ACCOUNT_SECRET_ID']))
-            self._admin_credentials = service_account.Credentials.from_service_account_info(info)
+                secret_service.get_secret_payload(
+                    secret_id=settings.config["ADMIN_SERVICE_ACCOUNT_SECRET_ID"]
+                )
+            )
+            self._admin_credentials = (
+                service_account.Credentials.from_service_account_info(info)
+            )
+            self._admin_credentials_source = (
+                f"secret:{settings.config['ADMIN_SERVICE_ACCOUNT_SECRET_ID']}"
+            )
         return self._admin_credentials
 
+    @property
+    def admin_db_project_id(self) -> str:
+        """GCP project id of the Firestore admin database in use."""
+        if self._admin_db_project_id is None:
+            _ = self.admin_db
+        return self._admin_db_project_id or ""
 
     @property
     def admin_db(self):
         if self._admin_db is None:
-            self._admin_db = firestore.Client(credentials=self.admin_credentials,
-                                              project=self.admin_credentials.project_id)
+            creds = self.admin_credentials
+            project_id = creds.project_id
+            self._admin_db = firestore.Client(
+                credentials=creds, project=project_id
+            )
+            self._admin_db_project_id = project_id
+            logging.info(
+                "Firestore admin DB project=%s (credentials from %s)",
+                project_id,
+                self._admin_credentials_source or "unknown",
+            )
         return self._admin_db
 
 

--- a/shared/slack_services.py
+++ b/shared/slack_services.py
@@ -156,6 +156,8 @@ def format_data_validation_slack_summary(response: dict) -> str:
             status = "completed"
         elif err:
             status = f"failed — {err}"
+        elif process.get("skipped"):
+            status = "skipped (skip_process_dataset=true)"
         else:
             status = "skipped"
         airtable = process.get("airtable") or {}
@@ -165,12 +167,18 @@ def format_data_validation_slack_summary(response: dict) -> str:
             airtable_s = f"Airtable update failed — {airtable.get('error')}"
         else:
             airtable_s = "Airtable date not updated"
+        busy_retries = process.get("busy_retries") or 0
+        attempts = process.get("attempts") or 0
+        retry_note = ""
+        if busy_retries or attempts > 1:
+            retry_note = f" · attempts={attempts}, busy_retries={busy_retries}"
         lines.extend(
             [
                 "",
                 "*Processed dataset workflow*",
                 f"• Notebook `{process.get('notebook') or 'process_dataset'}` on "
-                f"`{process.get('workflow') or 'process_dataset'}`: {status}",
+                f"`{process.get('workflow') or 'process_dataset'}`: {status}"
+                f"{retry_note}",
                 f"• Processed dataset `{processed_id}` · {airtable_s}",
             ]
         )

--- a/shared/utils.py
+++ b/shared/utils.py
@@ -154,6 +154,14 @@ class DatasetParameters(BaseModel):
         description="Required. Whether to write validated JSON to GCS and optionally Redivis.",
     )
     is_force_uploading_to_redivis: bool = False
+    skip_process_dataset: bool = Field(
+        default=False,
+        description=(
+            "If true, skip the process_dataset workflow after a successful raw "
+            "Redivis release. Omit/false/null keep the default (run processing). "
+            "Existing cron payloads need no change."
+        ),
+    )
     send_slack: bool = Field(
         default=False,
         description=(
@@ -163,14 +171,23 @@ class DatasetParameters(BaseModel):
     )
     orgs: List[Organization] = Field(min_length=1)
 
-    @field_validator("send_slack", mode="before")
-    @classmethod
-    def coerce_send_slack(cls, v):
+    @staticmethod
+    def _coerce_bool(v) -> bool:
         if v is None:
             return False
         if isinstance(v, str):
             return v.strip().lower() in ("true", "1", "yes")
         return bool(v)
+
+    @field_validator("send_slack", mode="before")
+    @classmethod
+    def coerce_send_slack(cls, v):
+        return cls._coerce_bool(v)
+
+    @field_validator("skip_process_dataset", mode="before")
+    @classmethod
+    def coerce_skip_process_dataset(cls, v):
+        return cls._coerce_bool(v)
 
     def to_dict(self):
         # Build a shorter description from params (also used for Redivis version text).
@@ -210,6 +227,7 @@ class DatasetParameters(BaseModel):
             "dataset_id": self.dataset_id,
             "is_save_to_storage": self.is_save_to_storage,
             "is_force_uploading_to_redivis": self.is_force_uploading_to_redivis,
+            "skip_process_dataset": self.skip_process_dataset,
             "send_slack": self.send_slack,
             "org_count": len(self.orgs),
             "orgs": full_description_org,

--- a/sync/special_dataset.py
+++ b/sync/special_dataset.py
@@ -1,0 +1,380 @@
+"""Build and run a multi-site validator dataset from Airtable Special Dataset rows."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+import settings
+from shared import utils
+from shared.airtable_services import AirtableServices
+from shared.slack_services import notify_slack
+from validators.data_validation_pipeline import run_data_validation
+from validators.redivis_services import RedivisServices
+
+
+def _field(name: str) -> str:
+    return settings.config[name]
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _single(value: Any, *, field_name: str) -> Any:
+    """Unwrap Airtable linked-record arrays that must contain one value."""
+    if isinstance(value, list):
+        if len(value) != 1:
+            raise ValueError(
+                f"{field_name} must contain exactly one value; got {value!r}"
+            )
+        return value[0]
+    return value
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _text(value).casefold() in {"1", "true", "yes", "checked"}
+
+
+def _date(value: Any, *, field_name: str) -> str:
+    text = _text(value)
+    if not text:
+        raise ValueError(f"{field_name} is required")
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(text, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+    raise ValueError(
+        f"{field_name} must be YYYY-MM-DD or M/D/YYYY; got {text!r}"
+    )
+
+
+def _user_filter(value: Any) -> dict | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        raise ValueError(f"user_filter must be JSON text or an object; got {value!r}")
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid user_filter JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("user_filter JSON must decode to an object")
+    return parsed
+
+
+def _user_limit(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"user_limit must be a positive integer; got {value!r}") from exc
+    if numeric < 1 or not numeric.is_integer():
+        raise ValueError(f"user_limit must be a positive integer; got {value!r}")
+    return int(numeric)
+
+
+def _row_to_org(row: dict, airtable: AirtableServices) -> utils.Organization:
+    fields = row.get("fields") or {}
+    linked_record_id = _text(
+        _single(
+            fields.get(_field("AIRTABLE_SPECIAL_FIELD_DATASET_LINK")),
+            field_name="dataset_link",
+        )
+    )
+    dataset_link = ""
+    if linked_record_id:
+        linked = airtable.get_dataset_record(linked_record_id)
+        dataset_link = _text(
+            (linked.get("fields") or {}).get(
+                settings.config["AIRTABLE_FIELD_REDIVIS_DATASET_NAME"]
+            )
+        )
+    firestore_org_id = _text(
+        _single(
+            fields.get(_field("AIRTABLE_SPECIAL_FIELD_ORG_ID")),
+            field_name="org_id",
+        )
+    )
+    is_guest = _bool(fields.get(_field("AIRTABLE_SPECIAL_FIELD_IS_GUEST")))
+    parsed_user_filter = _user_filter(
+        fields.get(_field("AIRTABLE_SPECIAL_FIELD_USER_FILTER"))
+    )
+    if not dataset_link:
+        if is_guest and parsed_user_filter:
+            dataset_link = f"guest-{_text(parsed_user_filter.get('value'))}"
+        else:
+            raise ValueError(f"row {row.get('id')} has no dataset_link")
+    if not firestore_org_id and not is_guest:
+        raise ValueError(f"row {row.get('id')} has no org_id")
+
+    filters: dict[str, Any] = {
+        "date_filter": {
+            "start_date": _date(
+                fields.get(_field("AIRTABLE_SPECIAL_FIELD_START_DATE")),
+                field_name="start_date",
+            ),
+            "end_date": _date(
+                fields.get(_field("AIRTABLE_SPECIAL_FIELD_END_DATE")),
+                field_name="end_date",
+            ),
+        },
+    }
+    if firestore_org_id:
+        filters["org_filter"] = {
+            "key": "districts",
+            "operator": "array_contains_any",
+            "value": [firestore_org_id],
+        }
+    if parsed_user_filter:
+        filters["user_filter"] = parsed_user_filter
+
+    return utils.Organization(
+        org_id=dataset_link,
+        is_guest=is_guest,
+        user_number_limit=_user_limit(
+            fields.get(_field("AIRTABLE_SPECIAL_FIELD_USER_LIMIT"))
+        ),
+        filters=filters,
+    )
+
+
+def _common_value(rows: list[dict], setting_key: str) -> str:
+    field = _field(setting_key)
+    values = {
+        _text((row.get("fields") or {}).get(field))
+        for row in rows
+        if _text((row.get("fields") or {}).get(field))
+    }
+    if len(values) > 1:
+        raise ValueError(
+            f"matching Airtable rows disagree on {field}: {sorted(values)}"
+        )
+    return next(iter(values), "")
+
+
+def _format_slack(result: dict) -> str:
+    verification = result.get("processed_verification") or {}
+    process = (result.get("validation") or {}).get("process_dataset") or {}
+    status = "succeeded" if result.get("success") else "failed"
+    lines = [
+        (
+            f"*Special dataset validation"
+            f"{' [TEST MODE]' if result.get('test_mode') else ''}* — {status}"
+        ),
+        "",
+        f"• Airtable configuration: `{result.get('dataset_name') or '—'}`",
+        f"• Raw output dataset: `{result.get('output_dataset_name') or '—'}`",
+        f"• Processed dataset: `{result.get('processed_name') or '—'}`",
+        f"• Airtable rows / validator orgs: {result.get('row_count', 0)}",
+        f"• Raw Redivis release: {'yes' if (result.get('validation') or {}).get('new_version_release') else 'no'}",
+        f"• `process_dataset`: {'completed' if process.get('ran') and not process.get('error') else 'failed/skipped'}",
+    ]
+    if result.get("test_mode"):
+        lines.append("• Airtable processed_ref_id verification/writeback: skipped")
+    else:
+        lines.extend(
+            [
+                (
+                    "• Processed ref: "
+                    f"`{verification.get('actual_ref_id') or '—'}` "
+                    f"(Airtable match: {verification.get('ref_matches')})"
+                ),
+                (
+                    "• Processed version: "
+                    f"`{verification.get('before_version') or 'none'}` → "
+                    f"`{verification.get('after_version') or 'none'}` "
+                    f"(updated: {verification.get('version_updated')})"
+                ),
+                (
+                    "• Airtable processed_ref_id backfilled: "
+                    f"{verification.get('rows_backfilled', 0)}"
+                ),
+            ]
+        )
+    errors = result.get("errors") or []
+    if process.get("error"):
+        errors = [*errors, f"process_dataset: {process['error']}"]
+    if errors:
+        lines.extend(["", "*Errors*"])
+        lines.extend(f"• {error}" for error in errors[:10])
+    return "\n".join(lines)
+
+
+def run_special_dataset_validation(
+    dataset_name: str,
+    *,
+    test_mode: bool = False,
+    test_dataset_name: str | None = None,
+) -> dict:
+    """
+    Read Special Dataset rows, run one forced multi-org raw release, process it,
+    then verify the configured processed dataset reference and version changed.
+
+    In test mode, Airtable still supplies the real query scopes, but output is
+    redirected to an explicit ``TEST-...-raw`` dataset. Airtable reference
+    verification and writes are skipped.
+    """
+    dataset_name = _text(dataset_name)
+    test_dataset_name = _text(test_dataset_name)
+    output_dataset_name = test_dataset_name if test_mode else dataset_name
+    result: dict[str, Any] = {
+        "operation": "special_dataset_validation",
+        "dataset_name": dataset_name,
+        "output_dataset_name": output_dataset_name,
+        "test_mode": test_mode,
+        "processed_name": None,
+        "row_count": 0,
+        "validation": None,
+        "processed_verification": None,
+        "success": False,
+        "errors": [],
+    }
+
+    try:
+        if not dataset_name:
+            raise ValueError("dataset_name is required")
+        suffix = settings.config["RAW_DATASET_SUFFIX"]
+        if not dataset_name.endswith(suffix):
+            raise ValueError(
+                f"dataset_name must be a raw dataset ending with {suffix!r}"
+            )
+        if test_mode:
+            if not test_dataset_name:
+                raise ValueError("test_dataset_name is required when test_mode=true")
+            if not test_dataset_name.startswith("TEST-"):
+                raise ValueError("test_dataset_name must start with 'TEST-'")
+            if not test_dataset_name.endswith(suffix):
+                raise ValueError(
+                    f"test_dataset_name must end with {suffix!r}"
+                )
+
+        airtable = AirtableServices()
+        rows = airtable.list_special_dataset_records(dataset_name)
+        result["row_count"] = len(rows)
+        if not rows:
+            raise ValueError(
+                f"No Special Dataset Airtable rows found for {dataset_name!r}"
+            )
+
+        configured_processed_name = _common_value(
+            rows, "AIRTABLE_SPECIAL_FIELD_PROCESSED_NAME"
+        ) or RedivisServices.processed_name_from_raw(dataset_name)
+        expected_processed = RedivisServices.processed_name_from_raw(dataset_name)
+        if configured_processed_name != expected_processed:
+            raise ValueError(
+                f"processed_name must be {expected_processed!r} for raw "
+                f"{dataset_name!r}; got {configured_processed_name!r}"
+            )
+        processed_name = RedivisServices.processed_name_from_raw(
+            output_dataset_name
+        )
+        result["processed_name"] = processed_name
+
+        orgs = [_row_to_org(row, airtable) for row in rows]
+
+        configured_ref = ""
+        before: dict = {}
+        before_ref = None
+        rs = RedivisServices()
+        if not test_mode:
+            configured_ref = _common_value(
+                rows, "AIRTABLE_SPECIAL_FIELD_PROCESSED_REF_ID"
+            )
+            rs.set_dataset(dataset_id=processed_name)
+            before = rs.get_current_dataset_status()
+            before_ref = rs.get_reference_id()
+
+        params = utils.DatasetParameters(
+            dataset_id=output_dataset_name,
+            is_save_to_storage=True,
+            is_force_uploading_to_redivis=True,
+            send_slack=False,  # This operation posts one combined summary.
+            orgs=orgs,
+        )
+        body, status = run_data_validation(
+            params,
+            slack_org_progress=False,
+            slack_summary_always=False,
+        )
+        validation = json.loads(body)
+        result["validation"] = validation
+        if status != 200:
+            raise RuntimeError(f"data_validation returned HTTP {status}")
+
+        process = validation.get("process_dataset") or {}
+        if test_mode:
+            if not validation.get("new_version_release"):
+                result["errors"].append(
+                    "test raw dataset did not produce a new released version"
+                )
+            if not process.get("ran") or process.get("error"):
+                result["errors"].append(
+                    "process_dataset did not complete successfully"
+                )
+            result["success"] = not result["errors"]
+            return result
+
+        rs.set_dataset(dataset_id=processed_name)
+        after = rs.get_current_dataset_status()
+        actual_ref = rs.get_reference_id()
+        ref_matches = bool(
+            actual_ref
+            and (not configured_ref or configured_ref == actual_ref)
+            and (not before_ref or before_ref == actual_ref)
+        )
+        version_updated = bool(
+            process.get("ran")
+            and not process.get("error")
+            and after.get("is_released")
+            and after.get("version_tag") != before.get("version_tag")
+        )
+
+        rows_backfilled = 0
+        ref_field = _field("AIRTABLE_SPECIAL_FIELD_PROCESSED_REF_ID")
+        if actual_ref and ref_matches:
+            for row in rows:
+                current = _text((row.get("fields") or {}).get(ref_field))
+                if not current:
+                    airtable.update_special_dataset_record_fields(
+                        row["id"], {ref_field: actual_ref}
+                    )
+                    rows_backfilled += 1
+
+        result["processed_verification"] = {
+            "configured_ref_id": configured_ref or None,
+            "actual_ref_id": actual_ref,
+            "ref_matches": ref_matches,
+            "before_version": before.get("version_tag"),
+            "after_version": after.get("version_tag"),
+            "is_released": after.get("is_released"),
+            "version_updated": version_updated,
+            "rows_backfilled": rows_backfilled,
+        }
+        if not ref_matches:
+            result["errors"].append(
+                "processed_ref_id does not match the processed Redivis dataset"
+            )
+        if not version_updated:
+            result["errors"].append(
+                "processed dataset did not produce a new released version"
+            )
+        result["success"] = not result["errors"]
+    except Exception as exc:
+        logging.exception("special_dataset_validation failed")
+        result["errors"].append(f"{type(exc).__name__}: {exc}")
+    finally:
+        try:
+            notify_slack(_format_slack(result))
+        except Exception:
+            logging.exception("special_dataset_validation Slack notification failed")
+
+    return result

--- a/trigger_main.py
+++ b/trigger_main.py
@@ -73,6 +73,7 @@ def _run_local_pipeline(body: dict) -> tuple[str, int]:
             "open_assignments_sync": job_main._run_open_assignments_sync,
             "weekly_report": job_main._run_weekly_report,
             "redivis_individual_release": job_main._run_redivis_individual_release,
+            "special_dataset_validation": job_main._run_special_dataset_validation,
             "migrate_scheduler_jobs": job_main._run_migrate_scheduler_jobs,
         }
         runner = runners.get(operation)

--- a/validators/data_validation_pipeline.py
+++ b/validators/data_validation_pipeline.py
@@ -56,6 +56,14 @@ def run_data_validation(
     """
     t0 = start_time if start_time is not None else time.time()
 
+    # Touch the admin client once so the Firestore project is logged before queries.
+    firestore_project = firestore_services.admin_db_project_id
+    logging.info(
+        "Syncing data from Firestore project=%s to Redivis for orgs: %s.",
+        firestore_project,
+        dataset_parameters.orgs,
+    )
+
     validated_data: dict = {}
     new_version_release = False
     total_validation_stats = {
@@ -70,7 +78,6 @@ def run_data_validation(
         "orgs": {},
     }
     org_count = len(dataset_parameters.orgs)
-    logging.info(f"Syncing data from Firestore to Redivis for orgs: {dataset_parameters.orgs}.")
 
     for org_index, org in enumerate(dataset_parameters.orgs, start=1):
         org_t0 = time.time()
@@ -231,31 +238,49 @@ def run_data_validation(
 
             # After a successful raw release, run process_dataset for this site:
             # source = dataset_id (*-raw), target = unmarked {Name}.
+            # Opt out with skip_process_dataset=true (cron payloads omit it).
             raw_suffix = settings.config["RAW_DATASET_SUFFIX"]
             raw_id = dataset_parameters.dataset_id or ""
             if release_ok and raw_id.endswith(raw_suffix):
-                process_log = rs.run_process_dataset_workflow(raw_dataset_id=raw_id)
-                if process_log.get("ran") and not process_log.get("error"):
-                    try:
-                        airtable = AirtableServices()
-                        airtable_log = airtable.update_processed_dataset_last_update(
-                            processed_name=process_log["processed_dataset_id"],
-                            date_yyyy_mm_dd=_today_in_pdt(),
-                        )
-                        process_log["airtable"] = airtable_log
-                    except Exception as e:
-                        logging.error(
-                            "Airtable processed-date update failed for %r: %s",
-                            process_log.get("processed_dataset_id"),
-                            e,
-                        )
-                        process_log["airtable"] = {
-                            "updated": False,
-                            "record_id": None,
-                            "error": str(e),
-                        }
+                if dataset_parameters.skip_process_dataset:
+                    processed_id = RedivisServices.processed_name_from_raw(raw_id)
+                    process_log = {
+                        "ran": False,
+                        "skipped": True,
+                        "raw_dataset_id": raw_id,
+                        "processed_dataset_id": processed_id,
+                        "workflow": settings.config["REDIVIS_PROCESS_WORKFLOW_NAME"],
+                        "notebook": settings.config["REDIVIS_PROCESS_NOTEBOOK_NAME"],
+                        "error": None,
+                        "airtable": None,
+                    }
+                    logging.info(
+                        "skip_process_dataset=true — skipped process_dataset for %r",
+                        raw_id,
+                    )
                 else:
-                    process_log.setdefault("airtable", None)
+                    process_log = rs.run_process_dataset_workflow(raw_dataset_id=raw_id)
+                    if process_log.get("ran") and not process_log.get("error"):
+                        try:
+                            airtable = AirtableServices()
+                            airtable_log = airtable.update_processed_dataset_last_update(
+                                processed_name=process_log["processed_dataset_id"],
+                                date_yyyy_mm_dd=_today_in_pdt(),
+                            )
+                            process_log["airtable"] = airtable_log
+                        except Exception as e:
+                            logging.error(
+                                "Airtable processed-date update failed for %r: %s",
+                                process_log.get("processed_dataset_id"),
+                                e,
+                            )
+                            process_log["airtable"] = {
+                                "updated": False,
+                                "record_id": None,
+                                "error": str(e),
+                            }
+                    else:
+                        process_log.setdefault("airtable", None)
 
         rs.upload_to_redivis_log["table_counts"] = rs.count_tables()
         output = {
@@ -275,6 +300,7 @@ def run_data_validation(
     response = {
         "operation": "data_validation",
         "dataset_parameters": dataset_parameters.to_dict(),
+        "firestore_project": firestore_project,
         "logs": output,
         "elapsed_time": elapsed_time,
         "api_version": settings.config["VERSION"],

--- a/validators/redivis_services.py
+++ b/validators/redivis_services.py
@@ -2,10 +2,16 @@ import redivis
 import logging
 import settings
 import os
+import time
 from shared.secret_services import secret_service
 from shared.utils import format_redivis_version_description
 
 logging.basicConfig(level=logging.INFO)
+
+# Redivis notebook job statuses that mean another process_dataset run is in flight.
+_NOTEBOOK_BUSY_STATUSES = frozenset(
+    {"running", "pending", "queued", "starting", "created"}
+)
 
 
 class RedivisServices:
@@ -286,6 +292,195 @@ class RedivisServices:
             if prev_id:
                 self.set_dataset(dataset_id=prev_id)
 
+    @staticmethod
+    def _is_notebook_busy_error(exc: BaseException) -> bool:
+        """True when Redivis rejected the run because the shared notebook is busy."""
+        msg = str(exc).lower()
+        return "already running" in msg
+
+    @staticmethod
+    def _notebook_is_busy(nb) -> bool:
+        """True when the notebook reports an in-flight ``currentJob``."""
+        try:
+            nb.get()
+            job = (nb.properties or {}).get("currentJob") or {}
+            status = str(job.get("status") or "").strip().lower()
+            return bool(status and status in _NOTEBOOK_BUSY_STATUSES)
+        except Exception as e:
+            logging.warning(
+                "run_process_dataset_workflow: could not read notebook "
+                "currentJob (continuing): %s",
+                e,
+            )
+            return False
+
+    def _wait_for_notebook_idle(self, nb, *, deadline: float, raw_dataset_id: str) -> bool:
+        """
+        Poll until the shared notebook has no busy ``currentJob``, or ``deadline``.
+
+        Returns True if idle (or status unreadable), False if still busy at deadline.
+        """
+        poll = max(5, int(settings.config["REDIVIS_PROCESS_BUSY_POLL_SECONDS"]))
+        while True:
+            if not self._notebook_is_busy(nb):
+                return True
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return False
+            sleep_for = min(poll, remaining)
+            logging.info(
+                "run_process_dataset_workflow: notebook busy — waiting %.0fs "
+                "before retry for %r (%.0fs left in budget)",
+                sleep_for,
+                raw_dataset_id,
+                remaining,
+            )
+            time.sleep(sleep_for)
+
+    def _point_workflow_datasource(
+        self,
+        data_source,
+        *,
+        source_qualified: str,
+        raw_dataset_id: str,
+    ) -> str | None:
+        """
+        Point the shared site datasource at ``raw_dataset_id``.
+
+        Returns an error string on mismatch/failure, else None.
+        """
+        data_source.update(source_dataset=source_qualified, version="current")
+        data_source.get()
+        actual_name = self._datasource_source_name(data_source)
+        if self._redivis_name_key(actual_name) != self._redivis_name_key(raw_dataset_id):
+            return (
+                f"workflow datasource source mismatch after update: "
+                f"wanted {raw_dataset_id!r}, got {actual_name!r}"
+            )
+        return None
+
+    def _run_shared_notebook_with_busy_retry(
+        self,
+        *,
+        nb,
+        data_source,
+        metadata_sources: list,
+        source_qualified: str,
+        target_qualified: str,
+        raw_dataset_id: str,
+        notebook_name: str,
+    ) -> dict:
+        """
+        Run the shared process_dataset notebook, waiting/retrying while it is busy.
+
+        Re-points the workflow datasource before each attempt so a concurrent job
+        cannot leave us pointed at the wrong site after we waited.
+        """
+        max_wait = max(
+            0, int(settings.config["REDIVIS_PROCESS_BUSY_RETRY_MAX_SECONDS"])
+        )
+        initial_sleep = max(
+            1, int(settings.config["REDIVIS_PROCESS_BUSY_RETRY_INITIAL_SECONDS"])
+        )
+        max_sleep = max(
+            initial_sleep,
+            int(settings.config["REDIVIS_PROCESS_BUSY_RETRY_MAX_SLEEP_SECONDS"]),
+        )
+        deadline = time.monotonic() + max_wait
+        attempt = 0
+        busy_retries = 0
+        next_sleep = initial_sleep
+        last_busy_error: str | None = None
+
+        while True:
+            attempt += 1
+            if not self._wait_for_notebook_idle(
+                nb, deadline=deadline, raw_dataset_id=raw_dataset_id
+            ):
+                return {
+                    "ran": False,
+                    "error": (
+                        "shared process_dataset notebook stayed busy for "
+                        f"{max_wait}s (last error: {last_busy_error or 'currentJob active'})"
+                    ),
+                    "busy_retries": busy_retries,
+                    "attempts": attempt,
+                }
+
+            # Another job may have swapped the datasource while we waited.
+            point_err = self._point_workflow_datasource(
+                data_source,
+                source_qualified=source_qualified,
+                raw_dataset_id=raw_dataset_id,
+            )
+            if point_err:
+                return {
+                    "ran": False,
+                    "error": point_err,
+                    "busy_retries": busy_retries,
+                    "attempts": attempt,
+                }
+
+            for ds in metadata_sources:
+                try:
+                    ds.update(version="current")
+                except Exception as e:
+                    logging.warning(
+                        "run_process_dataset_workflow: metadata datasource "
+                        "version=current refresh failed (continuing): %s",
+                        e,
+                    )
+
+            logging.info(
+                "run_process_dataset_workflow: running notebook %s "
+                "(source=%s target=%s attempt=%s busy_retries=%s)",
+                notebook_name,
+                source_qualified,
+                target_qualified,
+                attempt,
+                busy_retries,
+            )
+            try:
+                nb.run(wait_for_finish=True)
+                return {
+                    "ran": True,
+                    "error": None,
+                    "busy_retries": busy_retries,
+                    "attempts": attempt,
+                }
+            except Exception as e:
+                if not self._is_notebook_busy_error(e):
+                    return {
+                        "ran": False,
+                        "error": str(e),
+                        "busy_retries": busy_retries,
+                        "attempts": attempt,
+                    }
+                last_busy_error = str(e)
+                busy_retries += 1
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return {
+                        "ran": False,
+                        "error": (
+                            "shared process_dataset notebook stayed busy for "
+                            f"{max_wait}s (last error: {last_busy_error})"
+                        ),
+                        "busy_retries": busy_retries,
+                        "attempts": attempt,
+                    }
+                sleep_for = min(next_sleep, remaining, max_sleep)
+                logging.info(
+                    "run_process_dataset_workflow: %r — notebook already running; "
+                    "retry in %.0fs (busy_retries=%s, %.0fs left in budget)",
+                    raw_dataset_id,
+                    sleep_for,
+                    busy_retries,
+                    remaining,
+                )
+                time.sleep(sleep_for)
+                next_sleep = min(next_sleep * 2, max_sleep)
+
     def run_process_dataset_workflow(self, raw_dataset_id: str) -> dict:
         """
         Run Levante ``process_dataset`` for one site, driven only by ``raw_dataset_id``.
@@ -298,9 +493,9 @@ class RedivisServices:
 
         The shared workflow may still point at a previous site; this method always
         replaces the site (non-metadata) datasource with ``raw_dataset_id`` first,
-        then runs the notebook.
-
-        Note: concurrent jobs can race on the shared workflow datasource.
+        then runs the notebook. If another job holds the shared notebook, waits and
+        retries (re-pointing the datasource before each attempt) until the budget
+        in ``REDIVIS_PROCESS_BUSY_RETRY_MAX_SECONDS`` is exhausted.
         """
         raw_suffix = settings.config["RAW_DATASET_SUFFIX"]
         raw_dataset_id = (raw_dataset_id or "").strip()
@@ -315,6 +510,8 @@ class RedivisServices:
             "workflow": settings.config["REDIVIS_PROCESS_WORKFLOW_NAME"],
             "notebook": settings.config["REDIVIS_PROCESS_NOTEBOOK_NAME"],
             "error": None,
+            "busy_retries": 0,
+            "attempts": 0,
         }
         if not raw_dataset_id:
             result["error"] = "raw_dataset_id is empty"
@@ -392,43 +589,36 @@ class RedivisServices:
                 source_qualified,
                 target_qualified,
             )
-            data_source.update(source_dataset=source_qualified, version="current")
-            data_source.get()
-            actual_name = self._datasource_source_name(data_source)
-            if self._redivis_name_key(actual_name) != self._redivis_name_key(
-                raw_dataset_id
-            ):
-                result["error"] = (
-                    f"workflow datasource source mismatch after update: "
-                    f"wanted {raw_dataset_id!r}, got {actual_name!r}"
+
+            nb = wf.notebook(notebook_name)
+            run_result = self._run_shared_notebook_with_busy_retry(
+                nb=nb,
+                data_source=data_source,
+                metadata_sources=metadata_sources,
+                source_qualified=source_qualified,
+                target_qualified=target_qualified,
+                raw_dataset_id=raw_dataset_id,
+                notebook_name=notebook_name,
+            )
+            result["busy_retries"] = run_result.get("busy_retries", 0)
+            result["attempts"] = run_result.get("attempts", 0)
+            if run_result.get("error"):
+                result["error"] = run_result["error"]
+                logging.error(
+                    "run_process_dataset_workflow(%r) failed: %s",
+                    raw_dataset_id,
+                    result["error"],
                 )
-                logging.error("run_process_dataset_workflow: %s", result["error"])
                 return result
 
-            for ds in metadata_sources:
-                try:
-                    ds.update(version="current")
-                except Exception as e:
-                    logging.warning(
-                        "run_process_dataset_workflow: metadata datasource "
-                        "version=current refresh failed (continuing): %s",
-                        e,
-                    )
-
-            logging.info(
-                "run_process_dataset_workflow: running notebook %s "
-                "(source=%s target=%s)",
-                notebook_name,
-                source_qualified,
-                target_qualified,
-            )
-            nb = wf.notebook(notebook_name)
-            nb.run(wait_for_finish=True)
             result["ran"] = True
             logging.info(
-                "run_process_dataset_workflow: completed source=%s target=%s",
+                "run_process_dataset_workflow: completed source=%s target=%s "
+                "(attempts=%s busy_retries=%s)",
                 source_qualified,
                 target_qualified,
+                result["attempts"],
+                result["busy_retries"],
             )
         except Exception as e:
             result["error"] = str(e)


### PR DESCRIPTION
…-notebook busy retry.

1. Add special_dataset_validation (Airtable scopes → forced raw + process, with TEST mode). 
2. Allow skip_process_dataset so raw-only local/manual runs leave crons unchanged. 
3. Wait/retry when process_dataset:zr0v is already running; re-point datasource each attempt. 
4. For local ENV, read Firestore from LOCAL_ADMIN_SERVICE_ACCOUNT and log the project.
5. Updated slack notifications.